### PR TITLE
fix: corrected condition for safeDevice.

### DIFF
--- a/lib/safe_device.dart
+++ b/lib/safe_device.dart
@@ -37,21 +37,14 @@ class SafeDevice {
 
   // Check if device violates any of the above
   static Future<bool> get isSafeDevice async {
-    final bool isJailBroken = await _channel.invokeMethod('isJailBroken');
-    final bool isRealDevice = await _channel.invokeMethod('isRealDevice');
-    final bool canMockLocation = await SafeDevice.canMockLocation;
-    if (Platform.isAndroid) {
-      final bool isOnExternalStorage =
-          await _channel.invokeMethod('isOnExternalStorage');
-      return isJailBroken ||
-              canMockLocation ||
-              !isRealDevice ||
-              isOnExternalStorage == true
-          ? false
-          : true;
-    } else {
-      return isJailBroken || !isRealDevice || canMockLocation;
-    }
+    // Mock location isn't working properly hence, it will be kept separate. and not here.
+    // final bool canMockLocation = await SafeDevice.canMockLocation;
+    final bool isJailBroken = await SafeDevice.isJailBroken;
+    final bool isRealDevice = await SafeDevice.isRealDevice;
+    // When its Android, only at that time it requires to check externalStorage.
+    final bool isOnExternalStorage =
+        Platform.isAndroid && await SafeDevice.isOnExternalStorage;
+    return !isJail && isRealDevice && !isOnExternalStorage;
   }
 
   // (ANDROID ONLY) Check if development Options is enable on device


### PR DESCRIPTION
Condition in use currently is wrong. Hence fixed it. It will also address #28 .

Clarifications:
```dart
return isJailBroken || !isRealDevice || canMockLocation;
```

Above code, represent `unsafe` device, rather than how function is expecting `safeDevice`.

```dart
final bool canMockLocation = await SafeDevice.canMockLocation;
```
Above part is not working with android, as its throwing false, for even proper Android device as per testing.


Thanks.